### PR TITLE
Add `Debug` impls for public types

### DIFF
--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -1,5 +1,6 @@
 use crate::{NullTag, Shared, Shield, Tag};
 use std::{
+    fmt,
     marker::PhantomData,
     mem,
     sync::atomic::{AtomicUsize, Ordering},
@@ -185,4 +186,23 @@ where
     T1: Tag,
     T2: Tag,
 {
+}
+
+impl<V, T1, T2> fmt::Debug for Atomic<V, T1, T2>
+where
+    T1: Tag,
+    T2: Tag,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use crate::tag;
+        let data = self.data.load(Ordering::SeqCst);
+        let lo = tag::read_tag::<T1>(data, tag::TagPosition::Lo);
+        let hi = tag::read_tag::<T2>(data, tag::TagPosition::Hi);
+
+        f.debug_struct("Atomic")
+            .field("raw", &data)
+            .field("low_tag", &lo)
+            .field("high_tag", &hi)
+            .finish()
+    }
 }

--- a/src/cache_padded.rs
+++ b/src/cache_padded.rs
@@ -10,6 +10,7 @@ use std::ops::{Deref, DerefMut};
     not(any(target_arch = "x86_64", target_arch = "aarch64")),
     repr(align(64))
 )]
+#[derive(Debug)]
 pub struct CachePadded<T> {
     value: T,
 }

--- a/src/ebr/local.rs
+++ b/src/ebr/local.rs
@@ -7,6 +7,7 @@ use super::{
 use crate::{barrier::light_barrier, deferred::Deferred, CachePadded};
 use std::{
     cell::UnsafeCell,
+    fmt,
     marker::PhantomData,
     sync::{atomic::Ordering, Arc},
 };
@@ -151,5 +152,11 @@ impl Local {
     /// Returns true if this local has active shields and it's epoch is pinned.
     pub fn is_pinned(&self) -> bool {
         self.local_state.is_pinned()
+    }
+}
+
+impl fmt::Debug for Local {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("Local { .. }")
     }
 }

--- a/src/ebr/mod.rs
+++ b/src/ebr/mod.rs
@@ -8,6 +8,7 @@ pub use local::Local;
 pub use shield::{unprotected, CowShield, FullShield, Shield, ThinShield, UnprotectedShield};
 
 use global::Global;
+use std::fmt;
 use std::sync::Arc;
 
 const ADVANCE_PROBABILITY: usize = 128;
@@ -58,3 +59,9 @@ impl Default for Collector {
 
 unsafe impl Send for Collector {}
 unsafe impl Sync for Collector {}
+
+impl fmt::Debug for Collector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("Collector { .. }")
+    }
+}


### PR DESCRIPTION
Cf. https://github.com/jonhoo/flurry/pull/95 - the motivation is to be able to derive `Debug` for types containing a `Collector` or `Atomic`.

I've mostly followed `crossbeam` impls by providing raw pointers + tags for `Atomic` and type name only for the other types. Can change that if you want the impls to be `Arc` pointer value or something for `Collector`/`Local` and such.