### PR TITLE
Replaced `fn() -> Meta` with `&'static Meta`

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,3 +1,5 @@
+// if you thought the `barrier` and `deferred` modules were cursed, hoo boy are you in for a surprise
+
 use core::{
     fmt,
     mem::{self, MaybeUninit},


### PR DESCRIPTION
You can also use `std::mem::transmute` instead of `Transmuter` in Rust 1.46.0 if you want the size check.

This code starts compiling in Rust 1.36.0 because of `MaybeUninit`.